### PR TITLE
Channel Order Command Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <!-- Document properties -->
     <groupId>com.ibdiscord</groupId>
     <artifactId>IB.ai</artifactId>
-    <version>4.1.31</version>
+    <version>4.1.32</version>
 
     <name>IB.ai</name>
     <url>http://www.ibdiscord.com</url>

--- a/src/main/java/com/ibdiscord/command/actions/ChannelOrderSnapshot.java
+++ b/src/main/java/com/ibdiscord/command/actions/ChannelOrderSnapshot.java
@@ -44,16 +44,20 @@ public final class ChannelOrderSnapshot implements CommandAction {
         embedBuilder.setTitle("Order Of Channels");
 
         Gravity gravity = DataContainer.INSTANCE.getGravity();
+
+        ChannelData textChannelData = gravity.load(
+                new ChannelData(context.getGuild().getId(), "text")
+        );
+        textChannelData.getKeys().forEach(textChannelData::unset);
+
+        ChannelData voiceChannelData = gravity.load(
+                new ChannelData(context.getGuild().getId(), "voice")
+        );
+        voiceChannelData.getKeys().forEach(voiceChannelData::unset);
+
         Member selfMember = context.getGuild().getSelfMember();
 
         context.getGuild().getCategories().forEach(category -> {
-            ChannelData textChannelData = gravity.load(
-                    new ChannelData(context.getGuild().getId(), "text")
-            );
-
-            ChannelData voiceChannelData = gravity.load(
-                    new ChannelData(context.getGuild().getId(), "voice")
-            );
 
             List<GuildChannel> textChannels = category.getTextChannels().size() < 1 ? null :
                     category.modifyTextChannelPositions().getCurrentOrder().stream()

--- a/src/main/java/com/ibdiscord/command/registrar/RegistrarMod.java
+++ b/src/main/java/com/ibdiscord/command/registrar/RegistrarMod.java
@@ -88,7 +88,7 @@ public final class RegistrarMod implements CommandRegistrar {
                     );
                 });
 
-        registry.define("channelorder")
+        Command commandChannelOrder = registry.define("channelorder")
                 .restrict(CommandPermission.role(GuildData.MODERATOR))
                 .sub(registry.sub("snapshot", null)
                         .restrict(CommandPermission.discord(Permission.MANAGE_SERVER))
@@ -96,6 +96,7 @@ public final class RegistrarMod implements CommandRegistrar {
                 .sub(registry.sub("rollback", null)
                         .restrict(CommandPermission.role(GuildData.MODERATOR))
                         .on(new ChannelOrderRollback()));
+        commandChannelOrder.on(context -> context.replySyntax(commandChannelOrder));
 
         registry.define("shorten")
                 .restrict(CommandPermission.role(GuildData.MODERATOR))

--- a/src/main/java/com/ibdiscord/utils/UPermission.java
+++ b/src/main/java/com/ibdiscord/utils/UPermission.java
@@ -1,0 +1,36 @@
+/* Copyright 2020 Ray Clark
+ *
+ * This file is part of IB.ai.
+ *
+ * IB.ai is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * IB.ai is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with IB.ai. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.ibdiscord.utils;
+
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Member;
+
+public final class UPermission {
+
+    /**
+     * Checks if the given user can move the given channel.
+     * @param member The member in question.
+     * @param channel The channel in question.
+     * @return A boolean for is the user can move the channel.
+     */
+    public static boolean canMoveChannel(Member member, GuildChannel channel) {
+        return member.hasPermission(channel, Permission.MANAGE_CHANNEL) && member.hasPermission(channel, Permission.VIEW_CHANNEL);
+    }
+}


### PR DESCRIPTION
Added permission checks to Channel Order commands. 
Also added a response to Rollback, fixed formatting of Snapshot and gave Syntax response if no sub command given.
Finally changed the way channel IDs were stored for easier processing.
Tested on my private server.