### PR TITLE
Added Role Mention Check to repeater

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <!-- Document properties -->
     <groupId>com.ibdiscord</groupId>
     <artifactId>IB.ai</artifactId>
-    <version>4.1.33</version>
+    <version>4.1.34</version>
 
     <name>IB.ai</name>
     <url>http://www.ibdiscord.com</url>

--- a/src/main/java/com/ibdiscord/listeners/MessageListener.java
+++ b/src/main/java/com/ibdiscord/listeners/MessageListener.java
@@ -64,7 +64,9 @@ public final class MessageListener extends ListenerAdapter {
      */
     @Override
     public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
-        if(!event.getAuthor().isBot() && event.getMessage().getMentionedMembers().size() == 0) {
+        if(!event.getAuthor().isBot()
+                && event.getMessage().getMentionedMembers().size() == 0
+                && event.getMessage().getMentionedRoles().size() == 0) {
             repeater(event);
         }
         messageCache.put(event.getMessageIdLong(), new MinimalMessage(event.getAuthor().getIdLong(),


### PR DESCRIPTION
Bot won't repeat a message if it contains a Role message, just like it doesn't repeat if it contains a Member mention.