### PR TITLE
Fixed Repeater and Added Reply Toggling

### DIFF
--- a/lang/en/info.json
+++ b/lang/en/info.json
@@ -34,6 +34,8 @@
   "paginated": "Page {0}/{1}",
   "punished_user": "{0} punished {1}",
   "reminder_list": "Here is a list of your active reminders.",
+  "reply_disabled": "Bot replies have been disabled for {0}.",
+  "reply_enabled": "Bot replies have been enabled for {0}.",
   "supported_langs": "List of available languages. Use `{0}lang set <language>`",
   "tag_disabled": "The tag has been disabled.",
   "tag_enabled": "The tag has been enabled.",

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <!-- Document properties -->
     <groupId>com.ibdiscord</groupId>
     <artifactId>IB.ai</artifactId>
-    <version>4.1.42</version>
+    <version>4.1.43</version>
 
     <name>IB.ai</name>
     <url>http://www.ibdiscord.com</url>

--- a/src/main/java/com/ibdiscord/data/db/entries/ReplyData.java
+++ b/src/main/java/com/ibdiscord/data/db/entries/ReplyData.java
@@ -1,0 +1,38 @@
+/* Copyright 2018-2020 Arraying
+ *
+ * This file is part of IB.ai.
+ *
+ * IB.ai is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * IB.ai is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with IB.ai. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.ibdiscord.data.db.entries.monitor;
+
+import de.arraying.gravity.data.types.TypeSet;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public final class MonitorMessageData extends TypeSet {
+
+    private final String guild;
+
+    /**
+     * Gets the unique identifier.
+     * @return The identifier.
+     */
+    @Override
+    protected String getUniqueIdentifier() {
+        return "monitor_messages_" + guild;
+    }
+
+}

--- a/src/main/java/com/ibdiscord/data/db/entries/ReplyData.java
+++ b/src/main/java/com/ibdiscord/data/db/entries/ReplyData.java
@@ -16,13 +16,13 @@
  * along with IB.ai. If not, see http://www.gnu.org/licenses/.
  */
 
-package com.ibdiscord.data.db.entries.monitor;
+package com.ibdiscord.data.db.entries;
 
 import de.arraying.gravity.data.types.TypeSet;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public final class MonitorMessageData extends TypeSet {
+public final class ReplyData extends TypeSet {
 
     private final String guild;
 
@@ -32,7 +32,7 @@ public final class MonitorMessageData extends TypeSet {
      */
     @Override
     protected String getUniqueIdentifier() {
-        return "monitor_messages_" + guild;
+        return "reply_" + guild;
     }
 
 }


### PR DESCRIPTION
Fixed the repeater to only trigger if 4 unique people send the same message. Also added a Reply Toggling feature for tags and repeats, channels can have replies disabled using `&reply #channel`, it can be enabled using the same command. The reply toggling has an override for staff members to allow them to tag rules and such.