### PR TITLE
Post modlogs in specified staff channel

### DIFF
--- a/src/main/java/com/ibdiscord/command/actions/History.java
+++ b/src/main/java/com/ibdiscord/command/actions/History.java
@@ -21,6 +21,7 @@ package com.ibdiscord.command.actions;
 import com.ibdiscord.command.CommandAction;
 import com.ibdiscord.command.CommandContext;
 import com.ibdiscord.data.db.DataContainer;
+import com.ibdiscord.data.db.entries.GuildData;
 import com.ibdiscord.data.db.entries.punish.PunishmentData;
 import com.ibdiscord.data.db.entries.punish.PunishmentsData;
 import com.ibdiscord.punish.Punishment;
@@ -76,7 +77,7 @@ public final class History implements CommandAction {
             PunishmentData punishmentData = gravity.load(new PunishmentData(guild.getId(), caseId));
             PunishmentHandler punishmentHandler = new PunishmentHandler(guild, punishment);
 
-            TextChannel channel = punishmentHandler.getLogChannel();
+            TextChannel channel = punishmentHandler.getLogChannel(GuildData.MODLOGS);
             if(channel == null) {
                 context.replyI18n("error.reason_logging");
                 return;

--- a/src/main/java/com/ibdiscord/command/registrar/RegistrarMod.java
+++ b/src/main/java/com/ibdiscord/command/registrar/RegistrarMod.java
@@ -441,7 +441,7 @@ public final class RegistrarMod implements CommandRegistrar {
                     punishment.setReason(reason);
                     PunishmentData punishmentData = gravity.load(new PunishmentData(guild.getId(), caseId));
                     PunishmentHandler punishmentHandler = new PunishmentHandler(guild, punishment);
-                    TextChannel channel = punishmentHandler.getLogChannel();
+                    TextChannel channel = punishmentHandler.getLogChannel(GuildData.MODLOGS);
                     if(channel == null) {
                         context.replyI18n("error.reason_logging");
                         return;

--- a/src/main/java/com/ibdiscord/command/registrar/RegistrarSys.java
+++ b/src/main/java/com/ibdiscord/command/registrar/RegistrarSys.java
@@ -67,8 +67,12 @@ public final class RegistrarSys implements CommandRegistrar {
                 .on(new Logging(GuildData.LOGS));
 
         registry.define("modlog")
-                .restrict(CommandPermission.discord(Permission.MANAGE_SERVER))
-                .on(new Logging(GuildData.MODLOGS));
+                .sub(registry.sub("channel", null)
+                        .restrict(CommandPermission.discord(Permission.MANAGE_SERVER))
+                        .on(new Logging(GuildData.MODLOGS)))
+                .sub(registry.sub("staff", null)
+                        .restrict(CommandPermission.discord(Permission.MANAGE_SERVER))
+                        .on(new Logging(GuildData.MODLOGS_STAFF)));
 
         registry.define("moderator")
                 .restrict(CommandPermission.discord(Permission.MANAGE_SERVER))

--- a/src/main/java/com/ibdiscord/data/db/entries/GuildData.java
+++ b/src/main/java/com/ibdiscord/data/db/entries/GuildData.java
@@ -35,6 +35,11 @@ public final class GuildData extends TypeMap {
     public static final String MODLOGS = "modlogs";
 
     /**
+     * The modlogs staff key for Redis.
+     */
+    public static final String MODLOGS_STAFF = "modlogs_staff";
+
+    /**
      * The modlogs key for Redis.
      */
     public static final String UPDATES = "updates";

--- a/src/main/java/com/ibdiscord/data/db/entries/GuildData.java
+++ b/src/main/java/com/ibdiscord/data/db/entries/GuildData.java
@@ -40,7 +40,7 @@ public final class GuildData extends TypeMap {
     public static final String MODLOGS_STAFF = "modlogs_staff";
 
     /**
-     * The modlogs key for Redis.
+     * The updates key for Redis.
      */
     public static final String UPDATES = "updates";
 

--- a/src/main/java/com/ibdiscord/punish/PunishmentHandler.java
+++ b/src/main/java/com/ibdiscord/punish/PunishmentHandler.java
@@ -40,7 +40,7 @@ public final class PunishmentHandler {
         Gravity gravity = DataContainer.INSTANCE.getGravity();
         long caseNumber = gravity.load(new PunishmentsData(guild.getId())).size() + 1;
         punishment.dump(guild, caseNumber);
-        TextChannel channel = getLogChannel();
+        TextChannel channel = getLogChannel(GuildData.MODLOGS);
         if(channel == null) {
             return;
         }
@@ -49,6 +49,14 @@ public final class PunishmentHandler {
             punishmentData.set(PunishmentData.MESSAGE, success.getIdLong());
             gravity.save(punishmentData);
         });
+        TextChannel staff_channel = getLogChannel(GuildData.MODLOGS_STAFF);
+        if(staff_channel == null) {
+            return;
+        }
+        staff_channel.sendMessage(punishment
+                .redacting(false)
+                .getLogPunishment(guild, caseNumber))
+                .queue();
     }
 
     /**
@@ -57,7 +65,7 @@ public final class PunishmentHandler {
      * The only required data is the type, user display/id, staff display/id.
      */
     public void onRevocation() {
-        TextChannel channel = getLogChannel();
+        TextChannel channel = getLogChannel(GuildData.MODLOGS);
         if(channel != null) {
             channel.sendMessage(punishment.getLogRevocation()).queue();
         }
@@ -67,9 +75,9 @@ public final class PunishmentHandler {
      * Gets the log channel.
      * @return The possibly null log channel.
      */
-    public TextChannel getLogChannel() {
+    public TextChannel getLogChannel(String modlogs) {
         GuildData guildData = DataContainer.INSTANCE.getGravity().load(new GuildData(guild.getId()));
-        return guild.getTextChannelById(guildData.get(GuildData.MODLOGS)
+        return guild.getTextChannelById(guildData.get(modlogs)
                 .defaulting(0L)
                 .asLong());
     }


### PR DESCRIPTION
**Goal**: Add option to specify staff channel where modlogs can be posted on entry (will help with searchability in staff discussions)

- Add sub option to modlog command to allow for specified staff channel
- Added parameter to `getLogChannel` to prevent duplicate code
- Queue message to send in staff channel (if not null) and without redaction