### PR TITLE
Prevent bot output from pinging anyone

### DIFF
--- a/src/main/java/com/ibdiscord/utils/UString.java
+++ b/src/main/java/com/ibdiscord/utils/UString.java
@@ -89,8 +89,7 @@ public final class UString {
             throw new IllegalArgumentException("input null");
         }
         return input
-                .replace("@everyone", "@\u200Beveryone")
-                .replace("@here", "@\u200Bhere");
+                .replace("@", "@\u200B");
     }
 
     /**


### PR DESCRIPTION
Replaces all @ symbols with the @ symbol and the zero width space, instead of just @everyone and @here.